### PR TITLE
Fix comment typo in backup rules

### DIFF
--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -2,7 +2,7 @@
    Sample backup rules file; uncomment and customize as necessary.
    See https://developer.android.com/guide/topics/data/autobackup
    for details.
-   Note: This file is ignored for devices older that API 31
+   Note: This file is ignored for devices older than API 31
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>


### PR DESCRIPTION
## Summary
- correct minor typo in `backup_rules.xml` comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887944a3d4883339f9787bee2c991ac